### PR TITLE
Run db migrations on container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,8 @@ RUN groupadd --system --gid 1000 rails && \
 USER 1000:1000
 
 # Entrypoint prepares the database.
-# ENTRYPOINT ["/rails/bin/docker-entrypoint"]
+ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD ["./bin/rails", "server"]
+CMD ["./bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/README.md
+++ b/README.md
@@ -21,4 +21,7 @@ Things you may want to cover:
 
 * Deployment instructions
 
-* ...
+## Docker Setup
+
+Use `docker-compose up` to start the application in development. The `web`
+service automatically runs any pending database migrations on boot.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
   web:
     build: .
+    entrypoint: ./bin/docker-entrypoint
     command: ./bin/rails server -b 0.0.0.0 -p 3000
     environment:
       RAILS_ENV: development


### PR DESCRIPTION
## Summary
- run migrations automatically when starting the Docker container
- document Docker usage

## Testing
- `bundle install`
- `bundle exec rake test` *(fails: ActiveRecord::ConnectionNotEstablished)*

------
https://chatgpt.com/codex/tasks/task_e_6851a66ed8d08320961259ee15095290