### PR TITLE
Fix ApplicationRecord inheritance

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,3 @@
-# The application was generated without the Active Record framework. When
-# running in continuous integration, Rails will eager load files in
-# `app/models`, which would normally load ActiveRecord. Defining a minimal
-# `ApplicationRecord` prevents `NameError` exceptions when Active Record is not
-# available.
-class ApplicationRecord
+class ApplicationRecord < ActiveRecord::Base
+  primary_abstract_class
 end


### PR DESCRIPTION
## Summary
- hook ActiveRecord into ApplicationRecord so models get Rails associations

## Testing
- `bin/rake test` *(fails: Could not find rails-7.2.2.1, sprockets-rails-3.5.2, pg-1.5.9, puma-6.6.0, jbuilder-2.13.0, bootsnap-1.18.6, debu...)*

------
https://chatgpt.com/codex/tasks/task_e_6851a79e2e0883209b9901119f6e3d17