### PR TITLE
Add GameChannel WebSocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,21 @@ Things you may want to cover:
 
 Use `docker-compose up` to start the application in development. The `web`
 service automatically runs any pending database migrations on boot.
+
+## Joining a Game
+
+Each game has a `uuid` that players use to connect over WebSockets.
+Connect to `ws://localhost:3000/cable` with the following subscription
+payload:
+
+```json
+{"command":"subscribe","identifier":"{\"channel\":\"GameChannel\",\"uuid\":\"GAME_UUID\"}"}
+```
+
+After subscribing the server responds with the list of scavenger items for
+that game. Send a JSON message with `{ "action": "join", "name": "Player" }`
+to register as a player. Submitting photos is done with:
+
+```json
+{"action":"submit","player_id":1,"item_id":2,"photo":"/path/to/image.jpg"}
+```

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,11 @@
+require "securerandom"
+
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :uuid
+
+    def connect
+      self.uuid = SecureRandom.uuid
+    end
+  end
+end

--- a/app/channels/game_channel.rb
+++ b/app/channels/game_channel.rb
@@ -1,0 +1,26 @@
+class GameChannel < ApplicationCable::Channel
+  def subscribed
+    @game = Game.find_by(uuid: params[:uuid])
+    if @game
+      stream_for @game
+      transmit(type: "items", items: @game.items.order(:position).as_json)
+    else
+      reject
+    end
+  end
+
+  # Create a new player in this game and notify others
+  def join(data)
+    return unless @game
+    player = @game.players.create(name: data["name"], admin: false, total_score: 0)
+    GameChannel.broadcast_to(@game, type: "player_joined", player: player.as_json)
+  end
+
+  # Upload a photo submission for an item
+  def submit(data)
+    return unless @game
+    player = @game.players.find(data["player_id"])
+    item = @game.items.find(data["item_id"])
+    Submission.create(player: player, item: item, photo: data["photo"])
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,5 @@
 class Game < ApplicationRecord
   has_many :players, dependent: :destroy
   has_many :items, dependent: :destroy
+  has_many :submissions, through: :players
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,5 @@
 class Item < ApplicationRecord
   belongs_to :game
   has_many :submissions, dependent: :destroy
+  after_create_commit -> { GameChannel.broadcast_to(game, type: "new_item", item: as_json) }
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,4 +1,5 @@
 class Submission < ApplicationRecord
   belongs_to :player
   belongs_to :item
+  after_create_commit -> { GameChannel.broadcast_to(item.game, type: "submission", submission: as_json) }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :items
   resources :players
   resources :games
+  mount ActionCable.server => "/cable"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/channels/game_channel_test.rb
+++ b/test/channels/game_channel_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class GameChannelTest < ActionCable::Channel::TestCase
+  test "subscribes with uuid" do
+    game = Game.create!(uuid: "abcd")
+    game.items.create!(name: "item", position: 1)
+
+    subscribe(uuid: game.uuid)
+
+    assert subscription.confirmed?
+    assert_equal "items", transmissions.last[:type]
+  end
+end


### PR DESCRIPTION
## Summary
- add `GameChannel` and connection setup
- broadcast new items and submissions
- mount ActionCable endpoint
- document how to join a game via WebSocket

## Testing
- `bundle exec rubocop`
- `bundle exec rails test` *(fails: connection to server on socket `/var/run/postgresql/.s.PGSQL.5432` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9335e788320b30a94cbff037ef3